### PR TITLE
ci: fix svu url path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
      - name: Get svu
        run: |
-         URL="https://github.com/caarlos0/svu/releases/download/v${SVU_VERSION}/svu_${SVU_VERSION}_linux_amd64.tar.gz"
+         URL="https://github.com/caarlos0/svu/releases/download/v${SVU_VERSION}/svu_linux_amd64.tar.gz"
          wget --quiet $URL --output-document svu.tar.gz
          tar -xzf svu.tar.gz
          chmod +x svu


### PR DESCRIPTION
## Describe the Change

This PR fixes a CI issue where the svu download URL has changed.

## Checklist

- [x] Open Source License list updated? Use `make opensource` to update the list.

- [x] License header updated? Use `make license` to update the header.
