### PR TITLE
fix: report correct port in CLI output

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -121,7 +121,7 @@ func login() error {
 	http.HandleFunc("/close", closeHandler)
 	http.HandleFunc("/redirect", redirectHandler(GlobalStaticAssets, "web/redirect.html", "web/error.html", config, state, cliCfg.Credentials.CredentialsFile))
 
-	slog.Info("Listening on port 8080. Visit http://localhost:8080 to autenticate with the Whoop API and get an access token.")
+	slog.Info("Listening on port " + port + ". Visit http://localhost:" + port + " to autenticate with the Whoop API and get an access token.")
 	err = openBrowser("http://localhost:"+port, noAutoOpenBrowser)
 	if err != nil {
 		slog.Error("unable to open web browser automaticaly", "error", err)

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -67,7 +67,7 @@ The following steps will guide you through the process of setting up MyWhoop on 
 7. Download the MyWhoop Docker image.
 
     ```shell
-    docker pull ghcr.io/karl-cardenas-coding/mywhoop:v0.2.0
+    docker pull ghcr.io/karl-cardenas-coding/mywhoop:v0.3.0
     ```
 
 8. Create a directory where you want to store the MyWhoop data and credentials token. The command below creates a folder in your home directory and changes to that directory.
@@ -83,9 +83,9 @@ The following steps will guide you through the process of setting up MyWhoop on 
     --volume $PWD:/data  \
     -e WHOOP_CLIENT_ID=$WHOOP_CLIENT_ID \
     -e WHOOP_CLIENT_SECRET=$WHOOP_CLIENT_SECRET  \
-    ghcr.io/karl-cardenas-coding/mywhoop:v0.2.0 login \
+    ghcr.io/karl-cardenas-coding/mywhoop:v0.3.0 login \
     --no-auto-open \
-    --credentials /app/token.json
+    --credentials /data/token.json
     ```
 
     ```
@@ -112,9 +112,9 @@ The following steps will guide you through the process of setting up MyWhoop on 
     docker run --publish 8080:8080 --volume $PWD:/app \
     -e WHOOP_CLIENT_ID=$WHOOP_CLIENT_ID \
     -e WHOOP_CLIENT_SECRET=$WHOOP_CLIENT_SECRET \
-    ghcr.io/karl-cardenas-coding/mywhoop:v0.2.0 dump \
-    --credentials /app/token.json \
-    --location /app
+    ghcr.io/karl-cardenas-coding/mywhoop:v0.3.0 dump \
+    --credentials /data/token.json \
+    --location /data
     ```
 
     Upon successful download, the Whoop data will be saved in the `~/mywhoop/data/` directory. The final output will look similar to the following:


### PR DESCRIPTION
## Describe the Change

This PR fixes a bug when using a non-default port value with the `login` command. The CLI output did not reflect the new port in the message. The port was honored, but the message the user saw was always set to the default port `8080`

## Checklist

- [x] Open Source License list updated? Use `make opensource` to update the list.

- [x] License header updated? Use `make license` to update the header.
